### PR TITLE
 python modules are actually deployed on trusty with this version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
 
 
-.PHONY: flakes tests clean docs build
+.PHONY: flakes tests clean docs build install modules
 
 
 all: build
 
-build:
+build: modules
 	make -C build all
 
 debug:
 	make -C build debug
+
+modules:
+	/usr/bin/python2.7 -m compileall src/ybinlogp/
 
 install:
 	make -C build install

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+0.7
+---
+* Fixed a bug that prevented the .py files from being deployed on trusty
+
 0.6
 ---
 * Fixed a bug that would cause an EmptyEventError if ybinlogp received an event

--- a/build/Makefile
+++ b/build/Makefile
@@ -31,6 +31,7 @@ clean:
 ybinlogp.o: ybinlogp.c ybinlogp.h
 
 install: $(TARGETS)
-	install -d $(DESTDIR)/usr/bin $(DESTDIR)/usr/lib
+	install -d $(DESTDIR)/usr/bin $(DESTDIR)/usr/lib $(DESTDIR)/usr/lib/python2.7/dist-packages/ybinlogp
 	install libybinlogp.so* $(DESTDIR)/usr/lib
 	install ybinlogp $(DESTDIR)/usr/bin
+	install $(VPATH)/ybinlogp/*.py* $(DESTDIR)/usr/lib/python2.7/dist-packages/ybinlogp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ybinlogp (0.7-yelp1) lucid; urgency=low
+
+  * Upstream release 0.7
+
+ -- Matt Ullmer <meu@yelp.com>  Tue, 16 Jun 2015 14:24:00 -0800
+
 ybinlogp (0.6-yelp1) lucid; urgency=low
 
   * Upsream release 0.6

--- a/ybinlogp.spec
+++ b/ybinlogp.spec
@@ -1,5 +1,5 @@
 %define name ybinlogp
-%define version 0.6
+%define version 0.7
 %define release 1
 
 Summary: Library, program, and python bindings for parsing MySQL binlogs
@@ -26,9 +26,9 @@ make
 %install
 install -D -m 444 src/ybinlogp.h $RPM_BUILD_ROOT/usr/include/ybinlogp.h
 install -D -m 755 build/ybinlogp $RPM_BUILD_ROOT/usr/sbin/ybinlogp
-install -D -m 555 build/libybinlogp.so.1 $RPM_BUILD_ROOT/usr/lib64/libybinlogp.so.1
-install -D -m 555 build/libybinlogp.so $RPM_BUILD_ROOT/usr/lib64/libybinlogp.so
-install -D -d src/ybinlogp $RPM_BUILD_ROOT/usr/lib64/python2.6/site-packages/ybinlogp
+install -D -m 555 build/libybinlogp.so.1 $RPM_BUILD_ROOT/usr/lib/libybinlogp.so.1
+install -D -m 555 build/libybinlogp.so $RPM_BUILD_ROOT/usr/lib/libybinlogp.so
+install -D -d src/ybinlogp $RPM_BUILD_ROOT/usr/lib/python2.7/dist-packages/ybinlogp
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -36,7 +36,7 @@ rm -rf $RPM_BUILD_ROOT
 %files
 /usr/include/ybinlogp.h
 /usr/sbin/ybinlogp
-/usr/lib64/libybinlogp.so.1
-/usr/lib64/libybinlogp.so
-/usr/lib64/python2.6/site-packages/ybinlogp
+/usr/lib/libybinlogp.so.1
+/usr/lib/libybinlogp.so
+/usr/lib/python2.7/dist-packages/ybinlogp
 %defattr(-,root,root)


### PR DESCRIPTION
tools that import ybinlogp don't function on trusty unless the modules are present, this just compiles them and puts them in the correct spot
